### PR TITLE
Decode stdout using preferred encoding not ascii, and combine multibyte as necessary

### DIFF
--- a/epdb/epdb_client.py
+++ b/epdb/epdb_client.py
@@ -151,6 +151,7 @@ class TelnetClient(telnetlib.Telnet):
                             unicode_text = all_text.decode(encoding)
                             remaining_text = b""
                         except UnicodeDecodeError as e:
+                            assert e.start < 0, f"Got an unexpected negative start for unicode: {e.start}"
                             unicode_text = all_text[:e.start].decode(encoding)
                             remaining_text = all_text[e.start:]
                         sys.stdout.write(unicode_text)

--- a/epdb/epdb_client.py
+++ b/epdb/epdb_client.py
@@ -161,6 +161,10 @@ class TelnetClient(telnetlib.Telnet):
                     if not line:
                         break
                     self.write(line.encode(encoding))
+            if remaining_text:
+                # trying to decode remaining text which should fail and raise exception
+                # but that would be just what it is -- there was a non-decodable remainder
+                sys.stdout.write(remaining_text.decode(encoding))
         finally:
             self.restore_terminal()
 


### PR DESCRIPTION
Original use case was using the rich.inspect within epdb session.
https://pypi.org/project/rich/ is coloring output and uses UTF-8
characters for tables etc.  epdb  client was crashing unable to
decode:

	(Epdb) rich.inspect(self, value=False)
	Traceback (most recent call last):
	  File "<string>", line 1, in <module>
	  File "/home/yoh/proj/datalad/datalad-mihextras/venvs/dev3/lib/python3.9/site-packages/epdb/__init__.py", line 1091, in connect
		t.interact()
	  File "/home/yoh/proj/datalad/datalad-mihextras/venvs/dev3/lib/python3.9/site-packages/epdb/epdb_client.py", line 146, in interact
		sys.stdout.write(text.decode('ascii'))
	UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 5: ordinal not in range(128)

- I think hardcoding to `ascii` is the wrong thing to do since AFAIK
  there is no guarantee that it would *not* be UTF-8

- instead of leaving to default (not providing encoding) decided
  to go for prefered encoding

- there is a code block which follows for reading/writing stdin,
  and I encoded also into preferable encoding which allows now
  to pass unicode to be encoded to utf-8 happen someone needs
  to enter it.

Signed-off-by: Yaroslav Halchenko <debian@onerussian.com>

demo of it working:
![image](https://user-images.githubusercontent.com/39889/163876288-65ef0463-cd1c-4858-ae5a-fb90adbba5c5.png)
